### PR TITLE
RPi3 needs to boot in 64 bit mode

### DIFF
--- a/files3/config.txt
+++ b/files3/config.txt
@@ -1,4 +1,10 @@
+# set cpu into 64 bit mode
+arm_64bit=1                  # otherwise u-boot in 64 bit mode doesn't work
+
+# use u-boot as bootloader
 kernel=u-boot.bin
+
+# configure uart in such a way, that it works with fiasco.oc/genode
 enable_uart=1
 init_uart_baud=115200
-init_uart_clock=3000000 # this line is important
+init_uart_clock=3000000      # setting the clock is important


### PR DESCRIPTION
Signed-off-by: Alexander Weidinger <alexander.weidinger@tum.de>

Edit: arm_control is deprecated and one should use `arm_64bit=1`

https://www.raspberrypi.org/documentation/configuration/config-txt/misc.md